### PR TITLE
Fixed parsing of floating point numbers.

### DIFF
--- a/src/UkooLabs.SVGSharpie/SvgColorTranslator.cs
+++ b/src/UkooLabs.SVGSharpie/SvgColorTranslator.cs
@@ -30,7 +30,7 @@ namespace UkooLabs.SVGSharpie
                         byte ParsePercent(string str)
                         {
                             var trimmed = str.Trim().TrimEnd('%');
-                            var percent = Math.Max(0, Math.Min(100, float.Parse(trimmed)));
+                            var percent = Math.Max(0, Math.Min(100, float.Parse(trimmed, CultureInfo.InvariantCulture)));
                             var value = Math.Floor(255 * (percent / 100));
                             return (byte)value;
                         }

--- a/src/UkooLabs.SVGSharpie/SvgElementStyleDataDeserializer.cs
+++ b/src/UkooLabs.SVGSharpie/SvgElementStyleDataDeserializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -25,7 +26,7 @@ namespace UkooLabs.SVGSharpie
             ["stroke-width"] = CreateParserAndSetterForNullable(v => new SvgLength(v, SvgLengthContext.Null), s => s.StrokeWidth),
             ["stroke-linecap"] = CreateXmlEnumParserAndSetter(s => s.StrokeLineCap),
             ["stroke-linejoin"] = CreateXmlEnumParserAndSetter(s => s.StrokeLineJoin),
-            ["stroke-miterlimit"] = CreateParserAndSetterForNullable(float.Parse, s => s.StrokeMiterLimit),
+            ["stroke-miterlimit"] = CreateParserAndSetterForNullable(s => float.Parse(s, CultureInfo.InvariantCulture), s => s.StrokeMiterLimit),
             ["visibility"] = CreateXmlEnumParserAndSetter(s => s.Visibility),
             ["stroke-opacity"] = CreateParserAndSetterForInheritableNumber(s => s.StrokeOpacity),
             ["stroke-dasharray"] = CreateParserAndSetter(v =>
@@ -60,7 +61,7 @@ namespace UkooLabs.SVGSharpie
                 }
                 else
                 {
-                    var parsed = Math.Max(0, Math.Min(1, float.Parse(v.Value)));
+                    var parsed = Math.Max(0, Math.Min(1, float.Parse(v.Value, CultureInfo.InvariantCulture)));
                     value = new StyleProperty<float>(parsed, v.IsImportant);
                 }
                 s.FillOpacity = value;
@@ -141,7 +142,7 @@ namespace UkooLabs.SVGSharpie
                 }
                 else
                 {
-                    var parsedValue = float.Parse(value.Value);
+                    var parsedValue = float.Parse(value.Value, CultureInfo.InvariantCulture);
                     StyleProperty<float>? propertyValue = new StyleProperty<float>(parsedValue, isImportant: value.IsImportant);
                     propertyInfo.SetValue(style, propertyValue);
                 }

--- a/src/UkooLabs.SVGSharpie/SvgLength.cs
+++ b/src/UkooLabs.SVGSharpie/SvgLength.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace UkooLabs.SVGSharpie
 {
@@ -56,11 +57,11 @@ namespace UkooLabs.SVGSharpie
             if (unit < 0)
             {
                 LengthType = SvgLengthType.Number;
-                ValueInSpecifiedUnits = float.Parse(value);
+                ValueInSpecifiedUnits = float.Parse(value, CultureInfo.InvariantCulture);
             }
             else
             {
-                ValueInSpecifiedUnits = float.Parse(value.Substring(0, unit));
+                ValueInSpecifiedUnits = float.Parse(value.Substring(0, unit), CultureInfo.InvariantCulture);
                 switch (value.Substring(unit).ToLowerInvariant())
                 {
                     case "%":

--- a/src/UkooLabs.SVGSharpie/SvgPathSegListParser.cs
+++ b/src/UkooLabs.SVGSharpie/SvgPathSegListParser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Text;
 
 namespace UkooLabs.SVGSharpie
@@ -53,7 +54,8 @@ namespace UkooLabs.SVGSharpie
                         buffer.Append(stream.Read());
                     }
 
-                    args[arg] = float.Parse(buffer.ToString());
+                    args[arg] = float.Parse(buffer.ToString(), CultureInfo.InvariantCulture);
+                    
                 }
 
                 result.Add(CreatePathSegment(command, isNewCommand, args));

--- a/src/UkooLabs.SVGSharpie/SvgPolyPointListParser.cs
+++ b/src/UkooLabs.SVGSharpie/SvgPolyPointListParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace UkooLabs.SVGSharpie
 {
@@ -55,8 +56,8 @@ namespace UkooLabs.SVGSharpie
                     throw new Exception($"Invalid coordinate '{point}'");
                 }
 
-                coords.Add(float.Parse(point.Substring(0, signIndex)));
-                coords.Add(float.Parse(point.Substring(signIndex + 1)));
+                coords.Add(float.Parse(point.Substring(0, signIndex), CultureInfo.InvariantCulture));
+                coords.Add(float.Parse(point.Substring(signIndex + 1), CultureInfo.InvariantCulture));
             }
 
             AddCoordsToResult();

--- a/src/UkooLabs.SVGSharpie/SvgRect.cs
+++ b/src/UkooLabs.SVGSharpie/SvgRect.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace UkooLabs.SVGSharpie
 {
@@ -99,10 +100,10 @@ namespace UkooLabs.SVGSharpie
             }
             return new SvgRect
             (
-                float.Parse(values[0]),
-                float.Parse(values[1]),
-                float.Parse(values[2]),
-                float.Parse(values[3])
+                float.Parse(values[0], CultureInfo.InvariantCulture),
+                float.Parse(values[1], CultureInfo.InvariantCulture),
+                float.Parse(values[2], CultureInfo.InvariantCulture),
+                float.Parse(values[3], CultureInfo.InvariantCulture)
             );
         }
     }

--- a/src/UkooLabs.SVGSharpie/SvgStopElement.cs
+++ b/src/UkooLabs.SVGSharpie/SvgStopElement.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Serialization;
+﻿using System.Globalization;
+using System.Xml.Serialization;
 
 namespace UkooLabs.SVGSharpie
 {
@@ -86,10 +87,10 @@ namespace UkooLabs.SVGSharpie
 
             if (trimmed.EndsWith("%"))
             {
-                return float.Parse(trimmed.Substring(0, trimmed.Length - 1)) / 100;
+                return float.Parse(trimmed.Substring(0, trimmed.Length - 1), CultureInfo.InvariantCulture) / 100;
             }
 
-            return float.Parse(trimmed);
+            return float.Parse(trimmed, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/UkooLabs.SVGSharpie/SvgTransformListParser.cs
+++ b/src/UkooLabs.SVGSharpie/SvgTransformListParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -57,7 +58,7 @@ namespace UkooLabs.SVGSharpie
             {
                 throw new Exception($"Invalid matrix transformation arguments '{args}'");
             }
-            var values = split.Select(float.Parse).ToArray();
+            var values = split.Select(x => float.Parse(x, CultureInfo.InvariantCulture)).ToArray();
             return new SvgTransform(SvgTransformType.Matrix, new SvgMatrix(values));
         }
 
@@ -69,8 +70,8 @@ namespace UkooLabs.SVGSharpie
             {
                 throw new Exception($"Invalid scale transformation arguments '{args}'");
             }
-            var x = float.Parse(split[0]);
-            var y = split.Length == 2 ? float.Parse(split[1]) : x;
+            var x = float.Parse(split[0], CultureInfo.InvariantCulture);
+            var y = split.Length == 2 ? float.Parse(split[1], CultureInfo.InvariantCulture) : x;
             return new SvgTransform(SvgTransformType.Scale, SvgMatrix.CreateScale(x, y));
         }
 
@@ -90,9 +91,9 @@ namespace UkooLabs.SVGSharpie
             {
                 throw new Exception($"Invalid rotate transformation arguments '{args}'");
             }
-            var angle = float.Parse(split[0]);
-            var cx = split.Length > 1 ? (float?)float.Parse(split[1]) : null;
-            var cy = split.Length > 1 ? (float?)float.Parse(split[2]) : null;
+            var angle = float.Parse(split[0], CultureInfo.InvariantCulture);
+            var cx = split.Length > 1 ? (float?)float.Parse(split[1], CultureInfo.InvariantCulture) : null;
+            var cy = split.Length > 1 ? (float?)float.Parse(split[2], CultureInfo.InvariantCulture) : null;
             var matrix = SvgMatrix.CreateRotate(angle, cx, cy);
             return new SvgTransform(SvgTransformType.Rotate, matrix, angle);
         }
@@ -105,8 +106,8 @@ namespace UkooLabs.SVGSharpie
             {
                 throw new Exception($"Invalid translate transformation arguments '{args}'");
             }
-            var tx = float.Parse(split[0]);
-            var ty = split.Length == 2 ? float.Parse(split[1]) : tx;
+            var tx = float.Parse(split[0], CultureInfo.InvariantCulture);
+            var ty = split.Length == 2 ? float.Parse(split[1], CultureInfo.InvariantCulture) : tx;
             return new SvgTransform(SvgTransformType.Translate, SvgMatrix.CreateTranslate(tx, ty));
         }
 


### PR DESCRIPTION
SVG format contains numbers in invariant format. It have to be parsed on any system with any culture. Calling of float.Parse(str) throws an exception on systems where comma used in floating numbers.